### PR TITLE
Allow the user to stop execution of the program.

### DIFF
--- a/include/brainfuck.h
+++ b/include/brainfuck.h
@@ -111,6 +111,10 @@ typedef struct BrainfuckExecutionContext {
 	 * size of the tape in umber of cells.
 	 */
 	size_t tape_size;
+	/*
+	 * A flag that, if set to true, indicates that execution should stop.
+	 */
+	int shouldStop;
 } BrainfuckExecutionContext;
 
 /*
@@ -274,5 +278,13 @@ void brainfuck_destroy_context(struct BrainfuckExecutionContext *);
  *	other execution related variables.
  */
 void brainfuck_execute(struct BrainfuckInstruction *, struct BrainfuckExecutionContext *);
+
+/*
+ * Stops the currently running program referenced by the given execution context.
+ *
+ * @param context The context of this execution that contains the tape and
+ *	other execution related variables.
+ */
+void brainfuck_execution_stop(BrainfuckExecutionContext *);
 
 #endif /* BRAINFUCK_H */

--- a/src/brainfuck.c
+++ b/src/brainfuck.c
@@ -51,6 +51,7 @@ BrainfuckExecutionContext * brainfuck_context(int size) {
 	context->tape = tape;
 	context->tape_index = 0;
 	context->tape_size = size;
+	context->shouldStop = 0;
 	return context;
 }
 
@@ -505,5 +506,20 @@ void brainfuck_execute(BrainfuckInstruction *root, BrainfuckExecutionContext *co
 			return;
 		}
 		instruction = instruction->next;
+
+		if (context->shouldStop == 1) {
+			instruction = NULL;
+			return;
+		}
 	} 
+}
+
+/*
+ * Stops the currently running program referenced by the given execution context.
+ *
+ * @param context The context of this execution that contains the tape and
+ *	other execution related variables.
+ */
+void brainfuck_execution_stop(BrainfuckExecutionContext *context) {
+	context->shouldStop = 1;
 }


### PR DESCRIPTION
This requires the programmer to take a multithreaded approach and call brainfuck_execute from a separate, non-main thread.
