### PR TITLE
Make the interactive brainfuck commandline respond to EOF (Ctrl-d).

### DIFF
--- a/src/brainfuck.c
+++ b/src/brainfuck.c
@@ -218,6 +218,7 @@ BrainfuckInstruction * brainfuck_parse_stream_until(FILE *stream, const int unti
 	char ch;
 	char temp;
 	while ((ch = fgetc(stream)) != until) {
+		if (ch == EOF || feof(stream)) { break; }
 		instruction->type = ch;
 		instruction->difference = 1;
 		switch(ch) {

--- a/src/main.c
+++ b/src/main.c
@@ -103,6 +103,7 @@ void run_interactive_console() {
 	while(1) {
 		fflush(stdout);
 		instruction = brainfuck_parse_stream_until(stdin, '\n');
+		if (feof(stdin)) { break; }
 		brainfuck_add(state, instruction);
 		brainfuck_execute(instruction, context);
 		printf("\n>> ");


### PR DESCRIPTION
Implements behavior similar to interpreters such as python, node.
Will quit the interpreter when EOF, "^D", is entered as the
first character.