### PR TITLE
feat(#46): Add Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,26 @@ language: c
 matrix:
     include:
         - os: linux
-          compiler: gcc 
+          compiler: gcc
+          addons:
+              apt:
+                  packages:
+                      - libedit-dev
         - os: linux
           compiler: clang
+          addons:
+              apt:
+                  packages:
+                      - libedit-dev
         - os: osx
           compiler: gcc
         - os: osx
           compiler: clang
+
+# macOS dependencies
+before_install:  
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update         ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libedit; fi
 
 # Build steps
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+# Enable C support
+language: c
+
+# Build matrix
+matrix:
+    include:
+        - os: linux
+          compiler: gcc 
+        - os: linux
+          compiler: clang
+        - os: osx
+          compiler: gcc
+        - os: osx
+          compiler: clang
+
+# Build steps
+script:
+    - mkdir build
+    - cd build
+    - cmake .. && make VERBOSE=1

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-brainfuck
+brainfuck [![Build Status](https://travis-ci.org/fabianishere/brainfuck.svg?branch=master)](https://travis-ci.org/fabianishere/brainfuck)
 ===========
 Brainfuck interpreter written in C.
 


### PR DESCRIPTION
This change adds support for continuous integration via Travis. This
currently only builds the project and support for basic integration
tests should be added in the future.

Implements #46