### PR TITLE
Initialize tape memory to zero

### DIFF
--- a/src/brainfuck.c
+++ b/src/brainfuck.c
@@ -41,7 +41,7 @@ BrainfuckExecutionContext * brainfuck_context(int size) {
 	if (size < 0)
 		size = BRAINFUCK_TAPE_SIZE;
 
-	unsigned char* tape = malloc(sizeof(char) * size);
+	unsigned char* tape = calloc(size, sizeof(char));
 	
 	BrainfuckExecutionContext *context = (BrainfuckExecutionContext *) 
 			malloc(sizeof(BrainfuckExecutionContext));


### PR DESCRIPTION
- It is not guaranteed that memory is initialized to zero when
  allocating memory by malloc. Allocate memory by calloc, so that tape
  is always initialized to zero.