### PR TITLE
Add testing infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Debug
 bin
 lib
 build
+Testing
 
 # CMake Files
 Makefile

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,6 @@ before_install:
 
 # Build steps
 script:
-    - mkdir build
-    - cd build
+    - mkdir build && cd build
     - cmake .. && make VERBOSE=1
+    - ctest -VV

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,23 @@ project(brainfuck
     VERSION 2.7.3
 )
 
+include(CTest)
+
 option(ENABLE_CLI "Enable the command line interface." ON)
 option(ENABLE_EDITLINE "Enable GNU readline functionality provided by the editline library." ON)
 option(ENABLE_EXTENSION_DEBUG "Enable the debug extension for brainfuck.")
 option(INSTALL_EXAMPLES "Installs the examples.")
+
+if(MSVC)
+    # Force to always compile with W4
+    if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+        string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    else()
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+    endif()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -pedantic")
+endif()
 
 # getopt shim for windows
 add_library(getopt INTERFACE)
@@ -62,13 +75,6 @@ if(INSTALL_EXAMPLES)
     install(DIRECTORY examples DESTINATION ${EXAMPLES_DIR})
 endif()
 
-if(MSVC)
-    # Force to always compile with W4
-    if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
-        string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-    else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
-    endif()
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -pedantic")
+if(BUILD_TESTING)
+    add_subdirectory(tests)
 endif()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,3 +45,7 @@ build:
     project: c:\projects\brainfuck\build\brainfuck.sln
     verbosity: minimal
     parallel: true
+
+# Test the project
+test_script:
+  - ctest -VV

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable(test-smoke smoke.c)
+target_link_libraries(test-smoke brainfuck)
+
+add_test(smoke test-smoke)

--- a/tests/smoke.c
+++ b/tests/smoke.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <brainfuck.h>
+
+/**
+ * Smoke test running a simple "Hello World" brainfuck program.
+ */
+int main() {
+    BrainfuckState *state = brainfuck_state();
+    BrainfuckExecutionContext *context = brainfuck_context(BRAINFUCK_TAPE_SIZE);
+    BrainfuckInstruction *instruction = brainfuck_parse_string("++++++++[>++++[>++>+++>+++>+<<<<-]>+>+>->>+[<]<-]>>.>---.+++++++..+++.>>.<-.<.++"
+                                                               "+.------.--------.>>+.>++.");
+    brainfuck_add(state, instruction);
+    brainfuck_execute(state->root, context);
+    brainfuck_destroy_context(context);
+    brainfuck_destroy_state(state);
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This change adds support for (unit) testing using CTest from CMake. In
addition, it adds a simple smoke test to verify the interpreter works.

Implements #64