### PR TITLE
Resolve dependencies via CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(brainfuck
         VERSION 2.7.3
         DESCRIPTION "Brainfuck interpreter written in C")
 
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+
 ## Compile-time options ##
 option(ENABLE_CLI "Enable the command line interface" ON)
 option(ENABLE_EDITLINE "Enable GNU readline functionality provided by the editline library" ON)
@@ -38,26 +40,25 @@ target_compile_definitions(brainfuck PUBLIC
 target_compile_features(brainfuck PRIVATE c_std_90)
 target_compile_options(brainfuck PRIVATE ${BRAINFUCK_C_FLAGS})
 
+## Compile-time features ##
+if(ENABLE_EXTENSION_DEBUG)
+    target_compile_definitions(brainfuck PRIVATE "-DBRAINFUCK_EXTENSION_DEBUG")
+endif()
+
 if(ENABLE_CLI)
     add_executable(brainfuck-cli src/main.c)
     set_target_properties(brainfuck-cli PROPERTIES
         OUTPUT_NAME "brainfuck"
     )
-    target_link_libraries(brainfuck-cli brainfuck getopt)
-    target_compile_options(brainfuck-cli PRIVATE ${BRAINFUCK_C_FLAGS})
-
+    target_link_libraries(brainfuck-cli PRIVATE brainfuck getopt)
+    target_compile_options(brainfuck-cli PRIVATE "${BRAINFUCK_C_FLAGS}")
 
     if(ENABLE_EDITLINE)
-        target_compile_definitions(brainfuck-cli PRIVATE "-DBRAINFUCK_EDITLINE_LIB")
-        target_link_libraries(brainfuck-cli -ledit)
+        find_package(editline REQUIRED)
+        target_compile_definitions(brainfuck-cli PRIVATE BRAINFUCK_EDITLINE_LIB)
+        target_link_libraries(brainfuck-cli PRIVATE editline)
     endif()
 endif()
-
-if(ENABLE_EXTENSION_DEBUG)
-    target_compile_definitions(brainfuck PRIVATE "-DBRAINFUCK_EXTENSION_DEBUG")
-endif()
-
-
 
 ## Installation ##
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,27 +1,15 @@
-﻿cmake_minimum_required(VERSION 3.1)
+﻿cmake_minimum_required(VERSION 3.8)
 
 project(brainfuck
-    LANGUAGES C
-    VERSION 2.7.3
-)
+        LANGUAGES C
+        VERSION 2.7.3
+        DESCRIPTION "Brainfuck interpreter written in C")
 
-include(CTest)
-
-option(ENABLE_CLI "Enable the command line interface." ON)
-option(ENABLE_EDITLINE "Enable GNU readline functionality provided by the editline library." ON)
-option(ENABLE_EXTENSION_DEBUG "Enable the debug extension for brainfuck.")
-option(INSTALL_EXAMPLES "Installs the examples.")
-
-if(MSVC)
-    # Force to always compile with W4
-    if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
-        string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-    else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
-    endif()
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -pedantic")
-endif()
+## Compile-time options ##
+option(ENABLE_CLI "Enable the command line interface" ON)
+option(ENABLE_EDITLINE "Enable GNU readline functionality provided by the editline library" ON)
+option(ENABLE_EXTENSION_DEBUG "Enable the debug extension for brainfuck")
+option(INSTALL_EXAMPLES "Install the examples")
 
 # getopt shim for windows
 add_library(getopt INTERFACE)
@@ -29,35 +17,35 @@ if (MSVC)
     target_include_directories(getopt INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/deps/getopt)
 endif()
 
-add_library(brainfuck include/brainfuck.h src/brainfuck.c)
-set_target_properties(brainfuck PROPERTIES
-    PUBLIC_HEADER "include/brainfuck.h"
-    C_STANDARD 90
-)
+## Target ##
+set(BRAINFUCK_H include/brainfuck.h)
+set(BRAINFUCK_C_FLAGS
+        $<$<OR:$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>,$<C_COMPILER_ID:GNU>>:
+            -Wall -Wextra>
+        $<$<C_COMPILER_ID:MSVC>:/Wall /Zi>)
+
+
+add_library(brainfuck ${BRAINFUCK_H} src/brainfuck.c)
 target_include_directories(brainfuck PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
-    $<INSTALL_INTERFACE:include/brainfuck/>
+    $<INSTALL_INTERFACE:include/>
 )
 target_compile_definitions(brainfuck PUBLIC
     "-DBRAINFUCK_VERSION_MAJOR=${PROJECT_VERSION_MAJOR}"
     "-DBRAINFUCK_VERSION_MINOR=${PROJECT_VERSION_MINOR}"
     "-DBRAINFUCK_VERSION_PATCH=${PROJECT_VERSION_PATCH}"
 )
-install(TARGETS brainfuck
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-    PUBLIC_HEADER DESTINATION include/brainfuck
-)
+target_compile_features(brainfuck PRIVATE c_std_90)
+target_compile_options(brainfuck PRIVATE ${BRAINFUCK_C_FLAGS})
 
 if(ENABLE_CLI)
     add_executable(brainfuck-cli src/main.c)
     set_target_properties(brainfuck-cli PROPERTIES
         OUTPUT_NAME "brainfuck"
-        C_STANDARD 90
     )
     target_link_libraries(brainfuck-cli brainfuck getopt)
-    install(TARGETS brainfuck-cli RUNTIME DESTINATION bin)
-    install(FILES man/brainfuck.1 DESTINATION "share/man/man1")
+    target_compile_options(brainfuck-cli PRIVATE ${BRAINFUCK_C_FLAGS})
+
 
     if(ENABLE_EDITLINE)
         target_compile_definitions(brainfuck-cli PRIVATE "-DBRAINFUCK_EDITLINE_LIB")
@@ -66,7 +54,23 @@ if(ENABLE_CLI)
 endif()
 
 if(ENABLE_EXTENSION_DEBUG)
-    add_definitions("-DBRAINFUCK_EXTENSION_DEBUG")
+    target_compile_definitions(brainfuck PRIVATE "-DBRAINFUCK_EXTENSION_DEBUG")
+endif()
+
+
+
+## Installation ##
+include(GNUInstallDirs)
+
+install(TARGETS brainfuck
+        EXPORT brainfuck-config)
+install(EXPORT brainfuck-config
+        NAMESPACE brainfuck::
+        DESTINATION "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/cmake")
+
+if (ENABLE_CLI)
+    install(TARGETS brainfuck-cli)
+    install(FILES man/brainfuck.1 DESTINATION "share/man/man1")
 endif()
 
 if(INSTALL_EXAMPLES)
@@ -75,6 +79,8 @@ if(INSTALL_EXAMPLES)
     install(DIRECTORY examples DESTINATION ${EXAMPLES_DIR})
 endif()
 
+## Testing ##
+include(CTest)
 if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,6 @@ option(ENABLE_EDITLINE "Enable GNU readline functionality provided by the editli
 option(ENABLE_EXTENSION_DEBUG "Enable the debug extension for brainfuck")
 option(INSTALL_EXAMPLES "Install the examples")
 
-# getopt shim for windows
-add_library(getopt INTERFACE)
-if (MSVC)
-    target_include_directories(getopt INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/deps/getopt)
-endif()
-
 ## Target ##
 set(BRAINFUCK_H include/brainfuck.h)
 set(BRAINFUCK_C_FLAGS
@@ -46,6 +40,7 @@ if(ENABLE_EXTENSION_DEBUG)
 endif()
 
 if(ENABLE_CLI)
+    find_package(getopt REQUIRED)
     add_executable(brainfuck-cli src/main.c)
     set_target_properties(brainfuck-cli PROPERTIES
         OUTPUT_NAME "brainfuck"

--- a/cmake/Findeditline.cmake
+++ b/cmake/Findeditline.cmake
@@ -1,0 +1,39 @@
+# Copyright (c) 2020 Fabian Mastenbroek
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+find_path(EDITLINE_INCLUDE_DIR editline/readline.h)
+find_library(EDITLINE_LIBRARY NAMES edit)
+
+set(EDITLINE_LIBRARIES ${EDITLINE_LIBRARY})
+set(EDITLINE_INCLUDE_DIRS ${EDITLINE_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+
+# handle the QUIETLY and REQUIRED arguments and set EDITLINE_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(editline DEFAULT_MSG EDITLINE_INCLUDE_DIR EDITLINE_LIBRARY)
+
+mark_as_advanced(EDITLINE_INCLUDE_DIR EDITLINE_LIBRARY)
+
+if(EDITLINE_FOUND)
+    add_library(editline SHARED IMPORTED GLOBAL)
+    set_property(TARGET editline PROPERTY IMPORTED_LOCATION ${EDITLINE_LIBRARY})
+    set_property(TARGET editline PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${EDITLINE_INCLUDE_DIRS})
+endif()

--- a/cmake/Findgetopt.cmake
+++ b/cmake/Findgetopt.cmake
@@ -1,0 +1,41 @@
+# Copyright (c) 2020 Fabian Mastenbroek
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+find_path(GETOPT_INCLUDE_DIR getopt.h)
+find_library(GETOPT_LIBRARY NAMES wingetopt getopt)
+
+set(GETOPT_LIBRARIES ${GETOPT_LIBRARY})
+set(GETOPT_INCLUDE_DIRS ${GETOPT_INCLUDE_DIR})
+
+mark_as_advanced(GETOPT_INCLUDE_DIR GETOPT_LIBRARY)
+
+if(GETOPT_LIBRARY)
+    add_library(getopt SHARED IMPORTED GLOBAL)
+    set_property(TARGET getopt PROPERTY IMPORTED_LOCATION ${GETOPT_LIBRARY})
+else()
+    add_library(getopt INTERFACE IMPORTED GLOBAL)
+endif()
+
+# Use getopt shim if needed
+if(GETOPT_INCLUDE_DIR)
+    set_property(TARGET getopt PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${GETOPT_INCLUDE_DIRS})
+else()
+    set_property(TARGET getopt PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/deps/getopt")
+endif()


### PR DESCRIPTION
This pull requests updates the CMake configuration of the project to use CMake functionality for linking the necessary dependencies to the application. Previously, the configuration assumed that the dependencies were correctly installed before build-time and used raw library flags (e.g. `-ledit`) to link to the appropriate libraries.

I have added two CMake modules for resolving the dependencies `editline` and `getopt` before build-time. These modules will fail and inform the user if they have not installed the necessary packages. This should hopefully resolve issues such as #73  and #67.